### PR TITLE
Fix duplicate sidebar in web pages

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -44,9 +44,9 @@ export default function Sidebar() {
       )}
 
       {/* Sidebar */}
-      <div className={`w-64 bg-white shadow-lg flex flex-col h-full z-40 transform transition-transform duration-300 ease-in-out ${
-        isMobileMenuOpen ? 'translate-x-0 fixed' : '-translate-x-full fixed'
-      } lg:translate-x-0 lg:relative lg:transform-none`}>
+      <div className={`w-64 bg-white shadow-lg flex flex-col min-h-screen z-40 transform transition-transform duration-300 ease-in-out ${
+        isMobileMenuOpen ? 'translate-x-0 fixed h-screen' : '-translate-x-full fixed h-screen'
+      } lg:h-auto lg:translate-x-0 lg:relative lg:transform-none`}>
         {/* Logo Section */}
         <div className="p-6 border-b border-neutral-200">
           <div className="flex items-center space-x-3">

--- a/client/src/pages/community.tsx
+++ b/client/src/pages/community.tsx
@@ -4,7 +4,6 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
-import Sidebar from "@/components/layout/sidebar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -121,10 +120,7 @@ export default function Community() {
   };
 
   return (
-    <div className="flex h-screen bg-neutral-50">
-      <Sidebar />
-      
-      <div className="flex-1 ml-64 overflow-auto">
+    <div className="overflow-auto">
         <header className="bg-white shadow-sm border-b border-neutral-200 p-6">
           <div className="flex items-center justify-between">
             <div>
@@ -300,6 +296,5 @@ export default function Community() {
           </div>
         </main>
       </div>
-    </div>
   );
 }

--- a/client/src/pages/course.tsx
+++ b/client/src/pages/course.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
-import Sidebar from "@/components/layout/sidebar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -44,10 +43,7 @@ export default function Course() {
   const progressPercentage = modules ? (completedModules.length / modules.length) * 100 : 0;
 
   return (
-    <div className="flex h-screen bg-neutral-50">
-      <Sidebar />
-      
-      <div className="flex-1 ml-64 overflow-auto">
+    <div className="overflow-auto">
         <header className="bg-white shadow-sm border-b border-neutral-200 p-6">
           <div className="flex items-center justify-between">
             <div>
@@ -196,6 +192,5 @@ export default function Course() {
           </Card>
         </main>
       </div>
-    </div>
   );
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { isUnauthorizedError } from "@/lib/authUtils";
-import Sidebar from "@/components/layout/sidebar";
 import StatsCards from "@/components/dashboard/stats-cards";
 import WeightChart from "@/components/dashboard/weight-chart";
 import QuickActions from "@/components/dashboard/quick-actions";
@@ -57,9 +56,7 @@ export default function Dashboard() {
   });
 
   return (
-    <div className="flex h-screen bg-neutral-50">
-      <Sidebar />
-      <div className="flex-1 lg:ml-64 overflow-auto">
+    <div className="overflow-auto">
         {/* Header */}
         <header className="bg-white shadow-sm border-b border-neutral-200 p-6">
           <div className="flex items-center justify-between">
@@ -260,6 +257,5 @@ export default function Dashboard() {
           </div>
         </main>
       </div>
-    </div>
   );
 }

--- a/client/src/pages/evolution.tsx
+++ b/client/src/pages/evolution.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
-import Sidebar from "@/components/layout/sidebar";
 import WeightForm from "@/components/weight-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -103,10 +102,8 @@ export default function Evolution() {
   };
 
   return (
-    <div className="flex h-screen bg-neutral-50">
-      <Sidebar />
-      
-      <div className="flex-1 lg:ml-64 overflow-auto">
+    <>
+      <div className="overflow-auto">
         <header className="bg-white shadow-sm border-b border-neutral-200 p-6">
           <div className="flex items-center justify-between">
             <div>
@@ -408,10 +405,10 @@ export default function Evolution() {
         </main>
       </div>
       
-      <WeightForm 
-        isOpen={showWeightForm} 
-        onClose={() => setShowWeightForm(false)} 
+      <WeightForm
+        isOpen={showWeightForm}
+        onClose={() => setShowWeightForm(false)}
       />
-    </div>
+    </>
   );
 }

--- a/client/src/pages/exercises.tsx
+++ b/client/src/pages/exercises.tsx
@@ -4,7 +4,6 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
-import Sidebar from "@/components/layout/sidebar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
@@ -132,10 +131,7 @@ export default function Exercises() {
   };
 
   return (
-    <div className="flex h-screen bg-neutral-50">
-      <Sidebar />
-      
-      <div className="flex-1 ml-64 overflow-auto">
+    <div className="overflow-auto">
         <header className="bg-white shadow-sm border-b border-neutral-200 p-6">
           <div className="flex items-center justify-between">
             <div>
@@ -392,6 +388,5 @@ export default function Exercises() {
           )}
         </main>
       </div>
-    </div>
   );
 }

--- a/client/src/pages/meals.tsx
+++ b/client/src/pages/meals.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
-import Sidebar from "@/components/layout/sidebar";
 import MealForm from "@/components/meals/meal-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -86,10 +85,8 @@ export default function Meals() {
   const totalPointsToday = todayMeals.reduce((sum: number, meal: any) => sum + (meal.points || 0), 0);
 
   return (
-    <div className="flex h-screen bg-neutral-50">
-      <Sidebar />
-      
-      <div className="flex-1 ml-64 overflow-auto">
+    <>
+      <div className="overflow-auto">
         <header className="bg-white shadow-sm border-b border-neutral-200 p-6">
           <div className="flex items-center justify-between">
             <div>
@@ -313,7 +310,7 @@ export default function Meals() {
       <MealForm 
         isOpen={showMealForm} 
         onClose={() => setShowMealForm(false)} 
-      />
-    </div>
+        />
+    </>
   );
 }

--- a/client/src/pages/reflection.tsx
+++ b/client/src/pages/reflection.tsx
@@ -4,7 +4,6 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
-import Sidebar from "@/components/layout/sidebar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -141,10 +140,7 @@ export default function Reflection() {
   };
 
   return (
-    <div className="flex h-screen bg-neutral-50">
-      <Sidebar />
-      
-      <div className="flex-1 ml-64 overflow-auto">
+    <div className="overflow-auto">
         <header className="bg-white shadow-sm border-b border-neutral-200 p-6">
           <div className="flex items-center justify-between">
             <div>
@@ -341,6 +337,5 @@ export default function Reflection() {
           </div>
         </main>
       </div>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove sidebar imports from page components
- render sidebar only in `App.tsx` to avoid duplicate sidebars
- adjust layouts of pages after removal

## Testing
- `npm run check` *(fails: Cannot find type definition file due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68518c9b0360832e9683e28143834c27