### PR TITLE
Fix meals listing by sending query params

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -29,7 +29,10 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey[0] as string, {
+    const [url, params] = queryKey as [string, Record<string, any> | undefined];
+    const query = params ? `?${new URLSearchParams(params).toString()}` : "";
+
+    const res = await fetch(`${url}${query}`, {
       credentials: "include",
     });
 


### PR DESCRIPTION
## Summary
- ensure react-query fetch function forwards query params

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68519368b114832e9be508dcaaf11c98