### PR TITLE
Add calorie calculator page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import Exercises from "@/pages/exercises";
 import Reflection from "@/pages/reflection";
 import Meals from "@/pages/meals";
 import Evolution from "@/pages/evolution";
+import Calculadora from "@/pages/calculadora";
 import Sidebar from "@/components/layout/sidebar";
 
 function Router() {
@@ -36,6 +37,7 @@ function Router() {
           <Route path="/comunidade" component={Community} />
           <Route path="/exercicios" component={Exercises} />
           <Route path="/espelho" component={Reflection} />
+          <Route path="/calculadora" component={Calculadora} />
           <Route path="/refeicoes" component={Meals} />
           <Route path="/evolucao" component={Evolution} />
           <Route component={NotFound} />

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -6,10 +6,11 @@ import {
   PlayCircle, 
   Users, 
   Brain, 
-  FlipHorizontal2, 
-  Utensils, 
+  FlipHorizontal2,
+  Utensils,
   TrendingUp,
-  MoreVertical
+  MoreVertical,
+  Calculator
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -23,6 +24,7 @@ export function Sidebar() {
     { name: "Comunidade", href: "/community", icon: Users },
     { name: "Academia da Mente", href: "/exercises", icon: Brain },
     { name: "Espelho", href: "/reflection", icon: FlipHorizontal2 },
+    { name: "Calculadora", href: "/calculadora", icon: Calculator },
     { name: "Refeições", href: "/meals", icon: Utensils },
     { name: "Evolução", href: "/evolution", icon: TrendingUp },
   ];

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation } from "wouter";
 import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
-import { Heart, BarChart3, Play, Users, Brain, FlipHorizontal2, Utensils, TrendingUp, LogOut, Menu, X } from "lucide-react";
+import { Heart, BarChart3, Play, Users, Brain, FlipHorizontal2, Utensils, TrendingUp, LogOut, Menu, X, Calculator } from "lucide-react";
 import { useState } from "react";
 
 export default function Sidebar() {
@@ -19,6 +19,7 @@ export default function Sidebar() {
     { path: "/comunidade", icon: Users, label: "Comunidade" },
     { path: "/exercicios", icon: Brain, label: "Academia da Mente" },
     { path: "/espelho", icon: FlipHorizontal2, label: "Espelho" },
+    { path: "/calculadora", icon: Calculator, label: "Calculadora" },
     { path: "/refeicoes", icon: Utensils, label: "Refeições" },
     { path: "/evolucao", icon: TrendingUp, label: "Evolução" },
   ];

--- a/client/src/data/taco.json
+++ b/client/src/data/taco.json
@@ -1,0 +1,12 @@
+[
+  {"id":1,"alimento":"Arroz, branco, cozido","kcal":128,"proteina":2.5,"carboidrato":28.1,"lipidio":0.2},
+  {"id":2,"alimento":"Feijão, carioca, cozido","kcal":76,"proteina":4.8,"carboidrato":13.6,"lipidio":0.5},
+  {"id":3,"alimento":"Frango, peito, grelhado","kcal":163,"proteina":31.0,"carboidrato":0.0,"lipidio":3.6},
+  {"id":4,"alimento":"Ovo, cozido","kcal":146,"proteina":13.3,"carboidrato":0.6,"lipidio":9.5},
+  {"id":5,"alimento":"Maçã, crua, com casca","kcal":65,"proteina":0.2,"carboidrato":17.5,"lipidio":0.1},
+  {"id":6,"alimento":"Banana, prata, crua","kcal":92,"proteina":1.0,"carboidrato":23.3,"lipidio":0.2},
+  {"id":7,"alimento":"Batata, inglesa, cozida","kcal":52,"proteina":1.3,"carboidrato":11.9,"lipidio":0.1},
+  {"id":8,"alimento":"Carne, bovina, patinho, cozido","kcal":219,"proteina":32.9,"carboidrato":0.0,"lipidio":9.0},
+  {"id":9,"alimento":"Leite, integral","kcal":61,"proteina":3.2,"carboidrato":4.7,"lipidio":3.4},
+  {"id":10,"alimento":"Iogurte natural, integral","kcal":61,"proteina":3.5,"carboidrato":4.6,"lipidio":3.5}
+]

--- a/client/src/pages/calculadora.tsx
+++ b/client/src/pages/calculadora.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import tacoData from "@/data/taco.json";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+
+interface TacoItem {
+  id: number;
+  alimento: string;
+  kcal: number;
+  proteina: number;
+  carboidrato: number;
+  lipidio: number;
+}
+
+export default function Calculadora() {
+  const [foodId, setFoodId] = useState<number | null>(null);
+  const [grams, setGrams] = useState(100);
+
+  const selectedFood = tacoData.find((f: TacoItem) => f.id === foodId);
+  const factor = grams / 100;
+
+  const calories = selectedFood ? selectedFood.kcal * factor : 0;
+  const protein = selectedFood ? selectedFood.proteina * factor : 0;
+  const carbs = selectedFood ? selectedFood.carboidrato * factor : 0;
+  const fat = selectedFood ? selectedFood.lipidio * factor : 0;
+
+  return (
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Calculadora de Calorias</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label>Alimento</Label>
+            <Select onValueChange={(val) => setFoodId(parseInt(val))}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Selecione o alimento" />
+              </SelectTrigger>
+              <SelectContent>
+                {tacoData.map((item: TacoItem) => (
+                  <SelectItem key={item.id} value={String(item.id)}>
+                    {item.alimento}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <Label>Quantidade (g)</Label>
+            <Input
+              type="number"
+              value={grams}
+              onChange={(e) => setGrams(parseFloat(e.target.value) || 0)}
+              min={0}
+            />
+          </div>
+
+          {selectedFood && (
+            <div className="space-y-2 mt-4">
+              <div className="text-3xl font-bold text-primary">
+                {calories.toFixed(1)} kcal
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-sm">
+                <div>
+                  Proteína: {protein.toFixed(1)} g
+                </div>
+                <div>
+                  Carboidrato: {carbs.toFixed(1)} g
+                </div>
+                <div>
+                  Gorduras: {fat.toFixed(1)} g
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `calculadora` page for calorie calculator
- include small TACO dataset
- add calculator route in app
- update sidebars with new Calculadora item

## Testing
- `npm install`
- `npm run check` *(fails: numerous pre-existing TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685197662ca0832eb1ac48462f56d216