### PR TITLE
Add dark mode switch

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <script>
+      (function () {
+        const stored = localStorage.getItem('theme');
+        if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import Meals from "@/pages/meals";
 import Evolution from "@/pages/evolution";
 import Calculadora from "@/pages/calculadora";
 import Sidebar from "@/components/layout/sidebar";
+import ThemeToggle from "@/components/ThemeToggle";
 
 function Router() {
   const { isAuthenticated, isLoading } = useAuth();
@@ -28,8 +29,9 @@ function Router() {
   }
 
   return (
-    <div className="flex min-h-screen bg-neutral-50">
+    <div className="relative flex min-h-screen bg-background">
       <Sidebar />
+      <ThemeToggle />
       <main className="flex-1 lg:pl-0">
         <Switch>
           <Route path="/" component={Dashboard} />

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -7,7 +7,7 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="flex h-screen bg-neutral-50 relative">
+    <div className="flex h-screen bg-background relative">
       <Sidebar />
       <ThemeToggle />
       <div className="flex-1 lg:ml-0 overflow-auto">

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import Sidebar from "./layout/sidebar";
+import ThemeToggle from "./ThemeToggle";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -6,8 +7,9 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="flex h-screen bg-neutral-50">
+    <div className="flex h-screen bg-neutral-50 relative">
       <Sidebar />
+      <ThemeToggle />
       <div className="flex-1 lg:ml-0 overflow-auto">
         <div className="lg:pl-4 p-4">
           {children}

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -30,16 +30,16 @@ export function Sidebar() {
   ];
 
   return (
-    <div className="w-64 bg-white shadow-lg flex flex-col fixed h-full z-10">
+    <div className="w-64 bg-card text-foreground shadow-lg flex flex-col fixed h-full z-10">
       {/* Logo Section */}
-      <div className="p-6 border-b border-neutral-200">
+      <div className="p-6 border-b border-border">
         <div className="flex items-center space-x-3">
           <div className="w-10 h-10 bg-gradient-to-br from-primary to-secondary rounded-xl flex items-center justify-center">
             <Heart className="text-white" size={20} />
           </div>
           <div>
-            <h1 className="text-lg font-semibold text-neutral-800">Emagrecimento</h1>
-            <p className="text-sm text-neutral-500">Inteligente</p>
+            <h1 className="text-lg font-semibold text-foreground">Emagrecimento</h1>
+            <p className="text-sm text-muted-foreground">Inteligente</p>
           </div>
         </div>
       </div>
@@ -55,9 +55,9 @@ export function Sidebar() {
               <Button
                 variant={isActive ? "default" : "ghost"}
                 className={`w-full justify-start space-x-3 ${
-                  isActive 
-                    ? "bg-primary text-white" 
-                    : "text-neutral-600 hover:bg-neutral-100"
+                  isActive
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted"
                 }`}
               >
                 <Icon size={20} />
@@ -69,7 +69,7 @@ export function Sidebar() {
       </nav>
 
       {/* User Profile */}
-      <div className="p-4 border-t border-neutral-200">
+      <div className="p-4 border-t border-border">
         <div className="flex items-center space-x-3">
           <img 
             src={user?.profileImageUrl || "https://images.unsplash.com/photo-1494790108755-2616b612b786?w=40&h=40&fit=crop&crop=face"}
@@ -77,14 +77,14 @@ export function Sidebar() {
             className="w-10 h-10 rounded-full object-cover"
           />
           <div className="flex-1">
-            <p className="font-medium text-neutral-800">
+            <p className="font-medium text-foreground">
               {user?.firstName || "Usuário"}
             </p>
-            <p className="text-sm text-neutral-500">
+            <p className="text-sm text-muted-foreground">
               Membro desde {user?.memberSince ? new Date(user.memberSince).toLocaleDateString('pt-BR', { month: 'short', year: 'numeric' }) : 'Recente'}
             </p>
           </div>
-          <Button variant="ghost" size="sm">
+          <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground">
             <MoreVertical size={16} />
           </Button>
         </div>

--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/hooks/useTheme";
+import { Button } from "@/components/ui/button";
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      className="fixed top-4 right-4 z-50"
+    >
+      {theme === "dark" ? <Sun size={20} /> : <Moon size={20} />}
+    </Button>
+  );
+}

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -33,7 +33,7 @@ export default function Sidebar() {
       {/* Mobile menu button */}
       <button
         onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-        className="lg:hidden fixed top-4 left-4 z-50 p-2 bg-white rounded-lg shadow-lg"
+        className="lg:hidden fixed top-4 left-4 z-50 p-2 bg-card rounded-lg shadow-lg"
       >
         {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
       </button>
@@ -45,11 +45,11 @@ export default function Sidebar() {
         />
       )}
       {/* Sidebar */}
-      <div className={`w-64 bg-white shadow-lg flex flex-col min-h-screen z-40 transform transition-transform duration-300 ease-in-out ${
+      <div className={`w-64 bg-card text-foreground shadow-lg flex flex-col min-h-screen z-40 transform transition-transform duration-300 ease-in-out ${
         isMobileMenuOpen ? 'translate-x-0 fixed h-screen' : '-translate-x-full fixed h-screen'
       } lg:h-auto lg:translate-x-0 lg:relative lg:transform-none`}>
         {/* Logo Section */}
-        <div className="p-6 border-b border-neutral-200">
+        <div className="p-6 border-b border-border">
           <div className="flex items-center justify-center">
             <img 
               src={Emagrecimento_Inteligente__1_} 
@@ -70,8 +70,8 @@ export default function Sidebar() {
                   onClick={closeMobileMenu}
                   className={`flex items-center space-x-3 px-4 py-3 rounded-lg transition-colors cursor-pointer ${
                     isActive
-                      ? "bg-primary text-white"
-                      : "text-neutral-600 hover:bg-neutral-100"
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-muted"
                   }`}
                 >
                   <span className="text-lg">{item.emoji}</span>
@@ -83,7 +83,7 @@ export default function Sidebar() {
         </nav>
 
         {/* User Profile */}
-        <div className="p-4 border-t border-neutral-200">
+        <div className="p-4 border-t border-border">
           <div className="flex items-center space-x-3 mb-3">
             <img 
               src={(user as any)?.profileImageUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent((user as any)?.firstName || 'U')}&background=random`}
@@ -91,10 +91,10 @@ export default function Sidebar() {
               className="w-10 h-10 rounded-full object-cover" 
             />
             <div className="flex-1">
-              <p className="font-medium text-neutral-800">
+              <p className="font-medium text-foreground">
                 {(user as any)?.firstName ? `${(user as any).firstName} ${(user as any).lastName || ''}`.trim() : 'Usuário'}
               </p>
-              <p className="text-sm text-neutral-500">
+              <p className="text-sm text-muted-foreground">
                 Membro desde {new Date((user as any)?.createdAt || Date.now()).toLocaleDateString('pt-BR', { month: 'short', year: 'numeric' })}
               </p>
             </div>
@@ -103,7 +103,7 @@ export default function Sidebar() {
             variant="outline" 
             size="sm" 
             onClick={handleLogout}
-            className="w-full text-neutral-600 hover:text-neutral-800"
+            className="w-full text-muted-foreground hover:text-foreground"
           >
             <LogOut className="w-4 h-4 mr-2" />
             Sair

--- a/client/src/hooks/useTheme.ts
+++ b/client/src/hooks/useTheme.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export function useTheme() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('theme') as 'light' | 'dark') || 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(t => (t === 'light' ? 'dark' : 'light'));
+  };
+
+  return { theme, toggleTheme };
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -39,26 +39,31 @@
 }
 
 .dark {
-  --background: hsl(240, 10%, 3.9%);
-  --foreground: hsl(0, 0%, 98%);
-  --muted: hsl(240, 3.7%, 15.9%);
+  --background: #121212;
+  --foreground: #ffffff;
+  --muted: #1e1e1e;
   --muted-foreground: hsl(240, 5%, 74.9%);
-  --popover: hsl(240, 10%, 3.9%);
-  --popover-foreground: hsl(0, 0%, 98%);
-  --card: hsl(240, 10%, 3.9%);
-  --card-foreground: hsl(0, 0%, 98%);
-  --border: hsl(240, 3.7%, 15.9%);
-  --input: hsl(240, 3.7%, 15.9%);
-  --primary: hsl(207, 90%, 54%);
+  --popover: #1e1e1e;
+  --popover-foreground: #ffffff;
+  --card: #1e1e1e;
+  --card-foreground: #ffffff;
+  --border: #2a2a2a;
+  --input: #2a2a2a;
+  --primary: hsl(207, 90%, 60%);
   --primary-foreground: hsl(211, 100%, 99%);
-  --secondary: hsl(142, 76%, 36%);
+  --secondary: hsl(142, 76%, 44%);
   --secondary-foreground: hsl(142, 100%, 99%);
-  --accent: hsl(240, 3.7%, 15.9%);
-  --accent-foreground: hsl(0, 0%, 98%);
-  --destructive: hsl(0, 62.8%, 30.6%);
-  --destructive-foreground: hsl(0, 0%, 98%);
+  --accent: hsl(33, 100%, 60%);
+  --accent-foreground: hsl(33, 100%, 10%);
+  --destructive: hsl(0, 62.8%, 40%);
+  --destructive-foreground: #ffffff;
   --ring: hsl(240, 4.9%, 83.9%);
   --radius: 0.5rem;
+  --chart-1: hsl(207, 90%, 60%);
+  --chart-2: hsl(142, 76%, 44%);
+  --chart-3: hsl(33, 100%, 58%);
+  --chart-4: hsl(271, 91%, 75%);
+  --chart-5: hsl(0, 84.2%, 65%);
 }
 
 @layer base {
@@ -69,7 +74,7 @@
   body {
     @apply font-sans antialiased text-foreground;
     font-family: 'Inter', sans-serif;
-    background-color: #FAFAFA;
+    background-color: var(--background);
   }
 
   /* Typography improvements */

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -64,6 +64,14 @@
   --chart-3: hsl(33, 100%, 58%);
   --chart-4: hsl(271, 91%, 75%);
   --chart-5: hsl(0, 84.2%, 65%);
+  --sidebar-background: #1e1e1e;
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: hsl(207, 90%, 60%);
+  --sidebar-primary-foreground: hsl(211, 100%, 99%);
+  --sidebar-accent: #2a2a2a;
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: #2a2a2a;
+  --sidebar-ring: hsl(240, 4.9%, 83.9%);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- support theme toggle on the client
- implement `ThemeToggle` component and hook
- apply updated dark colors with higher contrast
- load saved theme preference on startup

## Testing
- `npm run check` *(fails: TS errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68582d3f7438832e8158863ab8e15100