### PR TITLE
Fix answer evaluation for mind exercises

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -315,10 +315,8 @@ export class DatabaseStorage implements IStorage {
       // Multiple choice question
       const index = parseInt(answer);
       if (!isNaN(index) && Array.isArray(exercise.options)) {
-        // Accept either zero-based or one-based numbering in the database
-        correct =
-          index === exercise.correctOption ||
-          index === exercise.correctOption - 1;
+        // Convert the string answer to a number and compare directly
+        correct = index === exercise.correctOption;
       }
     } else if (exercise?.answer) {
       // Text-based question

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -315,7 +315,10 @@ export class DatabaseStorage implements IStorage {
       // Multiple choice question
       const index = parseInt(answer);
       if (!isNaN(index) && Array.isArray(exercise.options)) {
-        correct = index === exercise.correctOption;
+        // Accept either zero-based or one-based numbering in the database
+        correct =
+          index === exercise.correctOption ||
+          index === exercise.correctOption - 1;
       }
     } else if (exercise?.answer) {
       // Text-based question


### PR DESCRIPTION
## Summary
- correct answer validation for mind exercises so zero-based and one-based indices both work

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_685841328728832ebfe0c4a7cb61a043